### PR TITLE
Include verification of scroll tabs to prevent avatar animation

### DIFF
--- a/lib/app_clone/twitter_profile/twitter_profile_page.dart
+++ b/lib/app_clone/twitter_profile/twitter_profile_page.dart
@@ -22,41 +22,49 @@ class _TwitterProfilePageState extends State<TwitterProfilePage> {
         body: NotificationListener<ScrollUpdateNotification>(
           onNotification: (scrollNotification) {
             final pixels = scrollNotification.metrics.pixels;
-            if (expandedHeader - pixels <= kToolbarHeight) {
-              if (isExpanded) {
-                translate = 0.0;
-                setState(() {
-                  isExpanded = false;
-                });
-              }
-            } else {
-              translate = -avatarMaximumRadius + pixels;
-              if (translate > 0) {
-                translate = 0.0;
-              }
-              if (!isExpanded) {
-                setState(() {
-                  isExpanded = true;
-                });
-              }
-            }
 
-            offset = pixels * 0.4;
+            // check if scroll is vertical ( left to right OR right to left)
+            final scrollTabs = 
+              (scrollNotification.metrics.axisDirection == AxisDirection.right || 
+              scrollNotification.metrics.axisDirection == AxisDirection.left);
 
-            final newSize = (avatarMaximumRadius - offset);
-
-            setState(() {
-              if (newSize < avatarMinimumRadius) {
-                avatarRadius = avatarMinimumRadius;
-              } else if (newSize > avatarMaximumRadius) {
-                avatarRadius = avatarMaximumRadius;
+            if(!scrollTabs){ // and here prevents animation of avatar when you scroll tabs
+              if (expandedHeader - pixels <= kToolbarHeight) {
+                if (isExpanded) {
+                  translate = 0.0;
+                  setState(() {
+                    isExpanded = false;
+                  });
+                }
               } else {
-                avatarRadius = newSize;
+                translate = -avatarMaximumRadius + pixels;
+                if (translate > 0) {
+                  translate = 0.0;
+                }
+                if (!isExpanded) {
+                  setState(() {
+                    isExpanded = true;
+                  });
+                }
               }
-            });
+
+              offset = pixels * 0.4;
+
+              final newSize = (avatarMaximumRadius - offset);
+
+              setState(() {
+                if (newSize < avatarMinimumRadius) {
+                  avatarRadius = avatarMinimumRadius;
+                } else if (newSize > avatarMaximumRadius) {
+                  avatarRadius = avatarMaximumRadius;
+                } else {
+                  avatarRadius = newSize;
+                }
+              });
+            }
           },
           child: DefaultTabController(
-            length: 4,
+            length: 8,
             child: CustomScrollView(
               physics: ClampingScrollPhysics(),
               slivers: <Widget>[
@@ -169,6 +177,18 @@ class TwitterTabs extends SliverPersistentHeaderDelegate {
       child: TabBar(
         isScrollable: true,
         tabs: <Widget>[
+          Tab(
+            text: "Tweets",
+          ),
+          Tab(
+            text: "Tweets & replies",
+          ),
+          Tab(
+            text: "Media",
+          ),
+          Tab(
+            text: "Likes",
+          ),
           Tab(
             text: "Tweets",
           ),


### PR DESCRIPTION
Hi Diego,

I attended the first Flutter Talks that happened in Sao Paulo where you lectured.
There I met your github and really liked the twitter clone repository, but I found a bug when I needed to scroll tabs.

In the example, we have only 4 tabs, which do not enable scrolling. In the adjustment I was testing, I needed to include more tabs and when I needed to scroll them, I noticed that the code was calculating all axes. Any scroll within Notification started the avatar animation.

To prevent animation, I include an if if checking the scroll is left-> right or right-> left.
If true, then it does not start avatar animation, keeping the header the same.
If the scroll is vertical, it starts the animation normally, keeping the initial idea of ​​the project.

Here are videos highlighting the bug and another showing how the `if` solved this problem.

Bug - https://www.dropbox.com/s/fakjc3drzysqbb1/bug-scrolling-tabs.gif?dl=0

Fixed - https://www.dropbox.com/s/bh8jmbnyr0331zk/bug-fixed-scroll-tabs.gif?dl=0

I hope to have helped in this project, even just for examples. = D

Thanks