### PR TITLE
fixed main_split_image.dart's error

### DIFF
--- a/lib/split_image/main_split_image.dart
+++ b/lib/split_image/main_split_image.dart
@@ -17,7 +17,7 @@ class _MainSplitImageState extends State<MainSplitImage> {
         AssetImage("images/characters/broly.png", bundle: rootBundle);
     final imageKey = await assetImage.obtainKey(ImageConfiguration());
     final DecoderCallback decodeResize =
-        (Uint8List bytes, {int cacheWidth, int cacheHeight}) {
+        (Uint8List bytes, {bool allowUpscaling,int cacheWidth, int cacheHeight}) {
       return ui.instantiateImageCodec(bytes,
           targetHeight: cacheHeight, targetWidth: cacheWidth);
     };


### PR DESCRIPTION
Fixed this error on build:" error: The function expression type 'Future<Codec> Function(Uint8List, {int cacheHeight, int cacheWidth})' isn't of type 'Future<Codec> Function(Uint8List, {bool allowUpscaling, int cacheHeight, int cacheWidth})'. This means its parameter or return type doesn't match what is expected. Consider changing parameter type(s) or the returned type(s). (invalid_cast_function_expr at [flutter_samples] lib/split_image/main_split_image.dart:20)"

It was missing the bool allowupscaling  parameter. I have added that, and now its working just fine.

![Screenshot from 2020-10-02 14-02-04](https://user-images.githubusercontent.com/50454029/94904067-5adf2880-04b8-11eb-81f7-05456ba4769f.png)
