### PR TITLE
fix error due to breaking change in http 0.13

### DIFF
--- a/lib/fetch_data/main_fetch_data.dart
+++ b/lib/fetch_data/main_fetch_data.dart
@@ -17,8 +17,8 @@ class _MainFetchDataState extends State<MainFetchData> {
     setState(() {
       isLoading = true;
     });
-    final response =
-        await http.get("https://jsonplaceholder.typicode.com/photos");
+    final response = await http
+        .get(Uri.parse("https://jsonplaceholder.typicode.com/photos"));
     if (response.statusCode == 200) {
       list = (json.decode(response.body) as List)
           .map((data) => new Photo.fromJson(data))

--- a/lib/persistent_tabbar/page1.dart
+++ b/lib/persistent_tabbar/page1.dart
@@ -12,8 +12,8 @@ class _Page1State extends State<Page1> {
   var list = List();
 
   _loadList() async {
-    final response =
-        await http.get("https://jsonplaceholder.typicode.com/posts/");
+    final response = await http
+        .get(Uri.parse("https://jsonplaceholder.typicode.com/posts/"));
     if (response.statusCode == 200) {
       await Future.delayed(const Duration(seconds: 1));
       if (mounted) {

--- a/lib/persistent_tabbar/page2.dart
+++ b/lib/persistent_tabbar/page2.dart
@@ -13,8 +13,8 @@ class _Page2State extends State<Page2>
   var list = List();
 
   _loadList() async {
-    final response =
-        await http.get("https://jsonplaceholder.typicode.com/photos/");
+    final response = await http
+        .get(Uri.parse("https://jsonplaceholder.typicode.com/photos/"));
     if (response.statusCode == 200) {
       await Future.delayed(const Duration(seconds: 1));
       if (mounted) {


### PR DESCRIPTION
As you can see from below screenshot:
![image](https://user-images.githubusercontent.com/13610283/111277838-d6eab880-8673-11eb-82f6-941cae21d218.png)

And further discussion on solution can be found here:
https://github.com/dart-lang/http/issues/538

The breaking change of the http makes all the request originally in string, now must be Uri, if the user's Flutter is 2.0+

In this commit I was using Uri.parse to refactor all the place using http package method, changing the string to Uri.