### PR TITLE
fix: removes most warnings

### DIFF
--- a/lib/animations/menu_exploration/menu_exploration.dart
+++ b/lib/animations/menu_exploration/menu_exploration.dart
@@ -18,7 +18,7 @@ class MenuExploration extends StatefulWidget {
     this.height,
     this.onChanged,
     this.selectedValue,
-  })  : assert(options != null && options.isNotEmpty),
+  })  : assert(options.isNotEmpty),
         super(key: key);
 
   @override

--- a/lib/app_clone/movies_concept/movies_concept_page.dart
+++ b/lib/app_clone/movies_concept/movies_concept_page.dart
@@ -184,8 +184,10 @@ class _MoviesConceptPageState extends State<MoviesConceptPage> {
             left: size.width / 4,
             bottom: 20,
             width: size.width / 2,
-            child: RaisedButton(
-                color: Colors.black,
+            child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  primary: Colors.black,
+                ),
                 child: Text(
                   'BUY TICKET',
                   style: TextStyle(color: Colors.white),

--- a/lib/app_clone/photo_concept/photo_concept_page.dart
+++ b/lib/app_clone/photo_concept/photo_concept_page.dart
@@ -216,10 +216,12 @@ class _PhotoConceptPageState extends State<PhotoConceptPage> {
                     duration: duration),
                 Padding(
                   padding: const EdgeInsets.all(12.0),
-                  child: RaisedButton(
-                    color: Colors.redAccent,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(20.0),
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      primary: Colors.redAccent,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(20.0),
+                      ),
                     ),
                     onPressed: () {},
                     child: Padding(

--- a/lib/app_clone/sports_store/sports_store_page.dart
+++ b/lib/app_clone/sports_store/sports_store_page.dart
@@ -305,7 +305,7 @@ class _SportsStorePageState extends State<SportsStorePage> {
                                 child: Row(
                                   children: [
                                     Expanded(
-                                      child: OutlineButton(
+                                      child: OutlinedButton(
                                         onPressed: null,
                                         child: Text(
                                           '3',
@@ -317,7 +317,7 @@ class _SportsStorePageState extends State<SportsStorePage> {
                                       width: 10,
                                     ),
                                     Expanded(
-                                      child: OutlineButton(
+                                      child: OutlinedButton(
                                         onPressed: null,
                                         child: Text(
                                           '4',
@@ -329,7 +329,7 @@ class _SportsStorePageState extends State<SportsStorePage> {
                                       width: 10,
                                     ),
                                     Expanded(
-                                      child: OutlineButton(
+                                      child: OutlinedButton(
                                         onPressed: null,
                                         child: Text(
                                           '5',

--- a/lib/appbar_sliverappbar/sample3.dart
+++ b/lib/appbar_sliverappbar/sample3.dart
@@ -147,13 +147,16 @@ class AlbumWidget extends StatelessWidget {
                       color: Colors.white,
                     ),
                   ),
-                  RaisedButton(
+                  ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      primary: Colors.pinkAccent,
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(25),
                       ),
-                      color: Colors.pinkAccent,
-                      child: Text('ADD TO PLAYLIST'),
-                      onPressed: () => null)
+                    ),
+                    child: Text('ADD TO PLAYLIST'),
+                    onPressed: () => null,
+                  )
                 ],
               ),
             ),

--- a/lib/communication_widgets/child1_page.dart
+++ b/lib/communication_widgets/child1_page.dart
@@ -30,21 +30,21 @@ class Child1PageState extends State<Child1Page> {
             widget.title ?? value,
             style: Theme.of(context).primaryTextTheme.headline5,
           ),
-          RaisedButton(
+          ElevatedButton(
             //Update Parent from Child 1
             child: Text("Action 2"),
             onPressed: () {
               widget.child2Action2!("Update from Child 1");
             },
           ),
-          RaisedButton(
+          ElevatedButton(
             //Update Child 2 from Child 1
             child: Text("Action 3"),
             onPressed: () {
               widget.child2Action3!("Update from Child 1");
             },
           ),
-          RaisedButton(
+          ElevatedButton(
             //Change Tab from Child 1 to Child 2
             child: Text("Action 4"),
             onPressed: () {

--- a/lib/communication_widgets/parent_page.dart
+++ b/lib/communication_widgets/parent_page.dart
@@ -74,7 +74,7 @@ class ParentPageState extends State<ParentPage>
               textAlign: TextAlign.center,
             ),
           ),
-          RaisedButton(
+          ElevatedButton(
             //Update Child 1 from Parent
             child: Text("Action 1"),
             onPressed: () {

--- a/lib/fetch_data/main_fetch_data.dart
+++ b/lib/fetch_data/main_fetch_data.dart
@@ -39,7 +39,7 @@ class _MainFetchDataState extends State<MainFetchData> {
         ),
         bottomNavigationBar: Padding(
           padding: const EdgeInsets.all(8.0),
-          child: RaisedButton(
+          child: ElevatedButton(
             child: Text("Fetch Data"),
             onPressed: _fetchData,
           ),

--- a/lib/hero_animations/main_hero_animations.dart
+++ b/lib/hero_animations/main_hero_animations.dart
@@ -121,7 +121,7 @@ class _MainHeroAnimationsPageState extends State<MainHeroAnimationsPage> {
               )),
         ),
         actions: <Widget>[
-          OutlineButton(
+          OutlinedButton(
             onPressed: () => Navigator.of(context).pop(),
             child: Icon(Icons.close),
           ),

--- a/lib/hero_animations/page1.dart
+++ b/lib/hero_animations/page1.dart
@@ -20,7 +20,7 @@ class Page1 extends StatelessWidget {
                 ),
               ),
             ),
-            OutlineButton(
+            OutlinedButton(
               onPressed: () => Navigator.of(context).pop(),
               child: Icon(Icons.close),
             )

--- a/lib/hero_animations/page2.dart
+++ b/lib/hero_animations/page2.dart
@@ -33,7 +33,7 @@ class Page2 extends StatelessWidget {
                     )),
               ),
             ),
-            OutlineButton(
+            OutlinedButton(
               onPressed: () => Navigator.of(context).pop(),
               child: Icon(Icons.close),
             )

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,7 +36,7 @@ class MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
-    SystemChrome.setEnabledSystemUIOverlays([SystemUiOverlay.bottom]);
+    SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: [SystemUiOverlay.bottom]);
     return Scaffold(
       appBar: AppBar(
         title: Text("Flutter Samples"),

--- a/lib/scroll_controller/scroll_movement.dart
+++ b/lib/scroll_controller/scroll_movement.dart
@@ -48,11 +48,11 @@ class _ScrollMovementState extends State<ScrollMovement> {
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: <Widget>[
-                  RaisedButton(
+                  ElevatedButton(
                     child: Text("up"),
                     onPressed: _moveUp,
                   ),
-                  RaisedButton(
+                  ElevatedButton(
                     child: Text("down"),
                     onPressed: _moveDown,
                   )


### PR DESCRIPTION
# Changes

Fixes most dart warnings related to Flutter 2.0.

# Discussion

I've tried to migrate Android to Flutter embedding but I've found no alternatives to `getFlutterView().getViewTreeObserver()` and such so I kept it the same. Setting transparency should be as easy as overriding `getTransparencyMode` but I've no clue about the fullscreen thing.